### PR TITLE
Implemented BMP encoding for output to replace PPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /target
-*.ppm
+*.bmp

--- a/src/data_structures/image.rs
+++ b/src/data_structures/image.rs
@@ -40,6 +40,9 @@ impl Image {
         bytes[0x12..0x16].copy_from_slice(&(self.width as u32).to_le_bytes());
         bytes[0x16..0x1A].copy_from_slice(&(self.height as u32).to_le_bytes());
 
+        // Preallocate memory to optimise allocations
+        bytes.reserve_exact(self.width * self.height * 3);
+
         // Write the pixel data to the file in the right order
         for row in self.pixels.chunks(self.width).rev() {
             for pixel in row {

--- a/src/data_structures/image.rs
+++ b/src/data_structures/image.rs
@@ -2,16 +2,25 @@ use crate::data_structures::Color;
 use std::fs::File;
 use std::io::Write;
 
+static BMP_HEADER: [u8; 54] = [
+    b'B', b'M', 0, 0, 0, 0, 0, 0, 0, 0, 54, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 24,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+
 pub struct Image {
     pixels: Vec<u32>,
     pub width: usize,
-    pub height: usize
+    pub height: usize,
 }
 
 impl Image {
     pub fn new(width: usize, height: usize) -> Image {
         let pixels: Vec<u32> = vec![0xffffffff; width * height];
-        Image { pixels, width, height }
+        Image {
+            pixels,
+            width,
+            height,
+        }
     }
 
     pub fn set_pixel(&mut self, x: usize, y: usize, color: &Color) {
@@ -25,18 +34,28 @@ impl Image {
     }
 
     pub fn save(&self, filepath: &str) {
-        let mut output_string = format!("P3\n{} {}\n255\n", self.width, self.height);
+        let mut bytes = BMP_HEADER.to_vec();
 
-        for pixel in &self.pixels {
-            let r = (pixel & 0xff000000) >> 24;
-            let g = (pixel & 0x00ff0000) >> 16;
-            let b = (pixel & 0x0000ff00) >> 8;
+        // Set the width and height values in the header
+        bytes[0x12..0x16].copy_from_slice(&(self.width as u32).to_le_bytes());
+        bytes[0x16..0x1A].copy_from_slice(&(self.height as u32).to_le_bytes());
 
-            output_string.push_str(&format!("{} {} {}\n", r, g, b));
+        // Write the pixel data to the file in the right order
+        for row in self.pixels.chunks(self.width).rev() {
+            for pixel in row {
+                bytes.push(((pixel & 0xff000000) >> 24) as u8);
+                bytes.push(((pixel & 0x00ff0000) >> 16) as u8);
+                bytes.push(((pixel & 0x0000ff00) >> 8) as u8);
+            }
         }
 
+        // Set the file length in the header
+        let len = bytes.len() as u32;
+        bytes[0x02..0x06].copy_from_slice(&len.to_le_bytes());
+
+        // Write to disk
         let mut file = File::create(filepath).unwrap();
-        file.write(output_string.as_bytes()).unwrap();
+        file.write_all(&bytes).unwrap();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,43 +1,54 @@
-use fe_o::maths::Vector3;
-use fe_o::cameras::PerspectiveCamera;
-use fe_o::maths::Matrix4x4;
 use core::f64::consts::PI;
-use fe_o::shapes::*;
-use fe_o::materials as M;
-use fe_o::textures as T;
-use fe_o::data_structures::Scene;
+use fe_o::cameras::PerspectiveCamera;
 use fe_o::data_structures::Color;
-use fe_o::Renderer;
+use fe_o::data_structures::Scene;
+use fe_o::materials as M;
+use fe_o::maths::Matrix4x4;
+use fe_o::maths::Vector3;
+use fe_o::shapes::*;
+use fe_o::textures as T;
 use fe_o::traits::Material;
 use fe_o::traits::RenderObject;
+use fe_o::Renderer;
 
 fn main() {
-
-    let solid_blue_texture = Box::new(T::Constant::new(Color (0.2, 0.2, 0.9, 1.0)));
-    let solid_red_texture = Box::new(T::Constant::new(Color (0.9, 0.2, 0.2, 1.0)));
-    let checked_yellow_green_texture = Box::new(T::Checked::new(Color (0.2, 0.9, 0.2, 1.0), Color (0.9, 0.2, 0.9, 1.0), 5.0));
-    let ground_texture = Box::new(T::Checked::new(Color (0.5, 0.5, 0.5, 1.0), Color (0.1, 0.1, 0.1, 1.0), 1.0));
+    let solid_blue_texture = Box::new(T::Constant::new(Color(0.2, 0.2, 0.9, 1.0)));
+    let solid_red_texture = Box::new(T::Constant::new(Color(0.9, 0.2, 0.2, 1.0)));
+    let checked_yellow_green_texture = Box::new(T::Checked::new(
+        Color(0.2, 0.9, 0.2, 1.0),
+        Color(0.9, 0.2, 0.9, 1.0),
+        5.0,
+    ));
+    let ground_texture = Box::new(T::Checked::new(
+        Color(0.5, 0.5, 0.5, 1.0),
+        Color(0.1, 0.1, 0.1, 1.0),
+        1.0,
+    ));
 
     let materials: Vec<Box<dyn Material>> = vec![
         Box::new(M::Lambertian::new(ground_texture, 0.0)),
         Box::new(M::Lambertian::new(solid_blue_texture, 0.0)),
         Box::new(M::Lambertian::new(solid_red_texture, 0.1)),
-        Box::new(M::Lambertian::new(checked_yellow_green_texture, 0.0))
+        Box::new(M::Lambertian::new(checked_yellow_green_texture, 0.0)),
     ];
 
     let render_objects: Vec<Box<dyn RenderObject>> = vec![
-        Box::new(Sphere::new(Vector3 (0.0, 0.0, -1e4), 1e4, 0)),
-        Box::new(Sphere::new(Vector3 (0.0, 8.0, 1.0), 1.0, 1)),
-        Box::new(Sphere::new(Vector3 (-3.0, 14.0, 1.0), 1.0, 2)),
-        Box::new(Sphere::new(Vector3 (-5.0, 8.0, 0.0), 2.0, 3))
+        Box::new(Sphere::new(Vector3(0.0, 0.0, -1e4), 1e4, 0)),
+        Box::new(Sphere::new(Vector3(0.0, 8.0, 1.0), 1.0, 1)),
+        Box::new(Sphere::new(Vector3(-3.0, 14.0, 1.0), 1.0, 2)),
+        Box::new(Sphere::new(Vector3(-5.0, 8.0, 0.0), 2.0, 3)),
     ];
 
     let scene = Scene::new(render_objects, materials, Color(0.9, 0.9, 0.9, 1.0), 3);
 
-    let transform = Matrix4x4::create_frame_transform(Vector3 (0.0, 0.0, 2.0), Vector3 (1.0, 0.0, 0.0), Vector3 (0.0, 1.0, -0.2));
+    let transform = Matrix4x4::create_frame_transform(
+        Vector3(0.0, 0.0, 2.0),
+        Vector3(1.0, 0.0, 0.0),
+        Vector3(0.0, 1.0, -0.2),
+    );
     let camera = PerspectiveCamera::new(transform, 70.0 * PI / 180.0, 0.3, 8.0);
 
     let renderer = Renderer::new(scene, camera);
     let image = renderer.render(1024, 512);
-    image.save("output.ppm");
+    image.save("output.bmp");
 }


### PR DESCRIPTION
I've implemented a very basic bitmap encoder for outputting images since it's a lot easier to work with files in the BMP format as opposed to PPM files. It's not a full implementation of the bitmap format but it doesn't need to be for this purpose.